### PR TITLE
Xpathを用いてxmlを読み込み

### DIFF
--- a/conf.xml
+++ b/conf.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<config>
+<app>
     <server>
         <port>10891</port>
     </server>
     <sql>
-        <host></host>
-        <port></port>
-        <dbname><dbname>
-        <user></user>
+        <host>127.0.0.1</host>
+        <port>5432</port>
+        <dbname>python_web_db</dbname>
+        <user>root</user>
         <pass></pass>
-    <sql>
-</config>
+    </sql>
+</app>

--- a/server.py
+++ b/server.py
@@ -1,7 +1,12 @@
 import http.server
 import socketserver
+import xml.etree.ElementTree as ET
 
-PORT = 10891
+# xpathを使ってport番号を取得
+tree = ET.parse('conf.xml')
+root = tree.getroot()
+PORT = int(root.findall('.//server/port')[0].text)
+
 Handler = http.server.SimpleHTTPRequestHandler
 
 with socketserver.TCPServer(("", PORT), Handler) as httpd:


### PR DESCRIPTION
設定ファイル(conf.xml)を外出しして、アプリの管理をしやすくした。
Xpathを用いてconf.xmlのportノードからポート番号を取得し、サーバーを立てるようにした